### PR TITLE
Fixed problem with issue-list component pagination color

### DIFF
--- a/features/issues/components/issue-list/issue-list.module.scss
+++ b/features/issues/components/issue-list/issue-list.module.scss
@@ -51,7 +51,7 @@
 }
 
 .pageInfo {
-  color: color.$gray-300;
+  color: color.$gray-700;
   font: font.$text-sm-regular;
 }
 


### PR DESCRIPTION
This PR resolves the problem with issue-list component pagination color to better match the Figma design layout